### PR TITLE
fix: handle video thumbnails in Bunny Stream with fallback for missing data

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -108,7 +108,19 @@ class Plugin extends BasePlugin
 
             if ($fs instanceof BunnyStreamFs) {
                 $cdnHostname = App::parseEnv($fs->cdnHostname);
-                $event->url = 'https://' . $cdnHostname . '/' . $asset->getFilename() . '/thumbnail.jpg';
+                $videoId = $asset->getFilename();
+
+                try {
+                    $video = $fs->getVideo($videoId);
+                    if (isset($video['thumbnailFileName'])) {
+                        $event->url = 'https://' . $cdnHostname . '/' . $videoId . '/' . $video['thumbnailFileName'];
+                    } else {
+                        $event->url = 'https://' . $cdnHostname . '/' . $videoId . '/thumbnail.jpg';
+                    }
+                } catch (\Exception $e) {
+                    Craft::error('Bunny Stream error: ' . $e->getMessage(), __METHOD__);
+                    $event->url = 'https://' . $cdnHostname . '/' . $videoId . '/thumbnail.jpg';
+                }
             }
         });
 

--- a/src/fs/BunnyStreamFs.php
+++ b/src/fs/BunnyStreamFs.php
@@ -152,6 +152,16 @@ class BunnyStreamFs extends Fs
         }
     }
 
+    public function getVideo(string $videoId): array
+    {
+        try {
+            $response = $this->getClient()->request('GET', $videoId);
+            return Json::decode($response->getBody()->getContents());
+        } catch (RequestException $e) {
+            throw new FsException($e->getMessage(), 0, $e);
+        }
+    }
+
     public function read(string $path): string
     {
         throw new NotSupportedException('read() is not implemented.');


### PR DESCRIPTION
## Fix Bunny Stream thumbnail URL handling

This PR fixes an issue where the plugin assumed static thumbnail URLs, which would break when Bunny Stream regenerates thumbnails with new URLs.

The change implements proper dynamic URL handling to ensure thumbnails remain accessible even after Bunny Stream updates them.

Files changed:
- `src/Plugin.php` - Updated thumbnail URL logic
- `src/fs/BunnyStreamFs.php` - Added dynamic URL resolution